### PR TITLE
Prevent errors when comparing to non-IP values

### DIFF
--- a/IPy.py
+++ b/IPy.py
@@ -742,6 +742,9 @@ class IPint:
                 return 0
 
     def __eq__(self, other):
+        if not isinstance(other, IPint):
+            return False
+        
         return self.__cmp__(other) == 0
 
     def __lt__(self, other):


### PR DESCRIPTION
A small fix to prevent errors when comparing IP/IPint objects to non-IP/IPint values. This prevents errors when comparing to None for example.
